### PR TITLE
Enable log symlink to /var/opt/Experitest

### DIFF
--- a/tasks/linux-install.yml
+++ b/tasks/linux-install.yml
@@ -20,6 +20,7 @@
   - s3_download_url
   - launcher_file_name
   - application_properties
+  - logs_folder
 
 # set temp folder
 
@@ -129,6 +130,29 @@
     remote_src: yes
   become: yes
   ignore_errors: yes
+
+- name: make sure logs folder exists
+  file:
+    path: "{{ logs_folder }}"
+    state: directory
+    mode: 0777
+    owner: "{{ ansible_user_id }}"
+  become: yes
+
+- name: remove existing logs folder from installation folder
+  file:
+    path: "{{ installation_folder }}/logs"
+    state: absent
+  become: yes
+
+- name: create sym link for logs folder
+  file:
+    src: "{{ logs_folder }}"
+    dest: "{{ installation_folder }}/logs"
+    state: link
+    mode: 0777
+    owner: "{{ ansible_user_id }}"
+  become: yes
 
 # expose role output
 

--- a/vars/linux.yml
+++ b/vars/linux.yml
@@ -5,6 +5,8 @@ installation_folder: "{{ installation_root_folder }}/{{ app_name }}-{{ app_versi
 
 temp_folder: "/var/tmp/Experitest"
 
+logs_folder: "/var/opt/Experitest/{{ app_name }}/logs"
+
 service_name: "{{ app_name }}.service"
 
 service_file_path: "/etc/systemd/system/{{ service_name }}"


### PR DESCRIPTION
we collect all logs matching /var/opt/Experitest/**/*.log . Share manager logs were missing from here. Added symlink for the same. 